### PR TITLE
Add support for release ready directory structure.

### DIFF
--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -2,7 +2,7 @@
 
 # Either test the specified or all files.
 if [ $# -eq 0 ]
-    then test_files=`find test -name "*.erl" | grep "_test.erl"`;
+    then test_files=`find apps test -type f -name '*_test.erl' 2>/dev/null`;
     else test_files=$@;
 fi
 
@@ -15,4 +15,4 @@ do
 done
 
 # Invoke runner, assuming all files have been compiled to `ebin/`.
-erl -noshell -noinput -pa deps/*/ebin ebin -s etest_runner run_all $modules
+erl -noshell -noinput -pa deps/*/ebin apps/*/ebin ebin -s etest_runner run_all $modules


### PR DESCRIPTION
This commit introduces support for running tests from apps/
applications. Specifically, any file matching '__test.erl' under apps/ or
top-level test/ will now be considered a test_file, per bin/etest-runner. The
runner invocation has been made to include apps/_/ebin on the code path, as
well.

These changes have been made to support a common multi-application directory
structure.

Signed-off-by: Brian L. Troutwine brian@troutwine.us
