### PR TITLE
Grouping of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ compile:
 clean:
 	$(REBAR) clean
 
-test:
+test: compile
 	./bin/etest-runner
 
 .PHONY: all compile clean test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+REBAR=which rebar || ./rebar
+
+all: clean compile
+
+compile:
+	$(REBAR) get-deps compile
+
+clean:
+	$(REBAR) clean
+
+test:
+	./bin/etest-runner
+
+.PHONY: all compile clean test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# test
+# etest
 
 It is a lightweight, convention over configuration test framework for
 Erlang.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# etest
+# test
 
 It is a lightweight, convention over configuration test framework for
 Erlang.
@@ -77,32 +77,6 @@ etest has no concept of fixtures like eunit. If you need some
 data over and over inside of your tests, you can define macros or
 functions instead and call them from within your tests.
 
-
-## Focus Tests
-
-From time to time you might want to run a single test case out of your suite to quickly pin down where the underlying program fails. Thus we introduced the concept of _Focus Tests_, where you would _mark_ one or more test cases with the prefix `focus_`, then upon running your tests only the marked cases will be executed.
-
-Example:
-
-```erlang
--module(my_focus_test).
--compile(export_all).
-
-% Include etest's assertion macros.
--include_lib("etest/include/etest.hrl").
-
-% This case will be ignored.
-test_bar() ->
-    % ...
-    ?assert_equal(false, true).
-
-% This case will be run.
-focus_test_foo() ->
-    % ...
-    ?assert(true).
-```
-
-
 ## Demo
 
 There is a quick screencast on vimeo that shows how to use etest in your
@@ -146,3 +120,5 @@ tests in the `test` directory.
 
 Run ```deps/etest/bin/etest-runner test/integration/user_login_test.erl``` to
 execute a single test file.
+
+Provide the `-g GROUP` flag to run a single group.

--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -1,5 +1,37 @@
 #!/bin/sh
 
+usage() {
+    cat <<EOF
+USAGE: `basename $0` [OPTIONS] [TESTS]
+
+Run the given TESTS modules, optionally by specific group only.
+
+OPTIONS:
+ -h          Show this message
+ -g [GROUP]  Run the tests of the specified group.
+EOF
+}
+
+group=
+while getopts "hg:" option
+do
+     case $option in
+         h)
+             usage
+             exit 1
+             ;;
+         g)
+             group=$OPTARG
+             ;;
+         ?)
+             usage
+             exit
+             ;;
+     esac
+done
+
+shift $(($OPTIND-1))
+
 # Either test the specified or all files.
 if [ $# -eq 0 ]
     then test_files=`find apps test -type f -name '*_test.erl' 2>/dev/null`;
@@ -15,4 +47,12 @@ do
 done
 
 # Invoke runner, assuming all files have been compiled to `ebin/`.
-erl -noshell -noinput -pa deps/*/ebin apps/*/ebin ebin -s etest_runner run_all $modules
+CMD="erl -noshell -noinput -pa deps/*/ebin apps/*/ebin ebin\
+     -s etest_runner run_all $modules"
+
+if [ -n $group ]
+then
+    CMD="$CMD -group $group"
+fi
+
+exec $CMD

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,7 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [warnings_as_errors, debug_info,
+            warn_export_vars, warn_shadow_vars,
+            warn_obsolete_guard, warn_unused_import,
+            {src_dirs, ["src", "test"]}
+           ]}.
 {clean_files, ["ebin/*.beam"]}.
 {xref_checks, [exports_not_used, undefined_function_calls]}.

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -1,23 +1,21 @@
 -module (etest_runner).
--compile (export_all).
+-export([run_all/0, run_all/1]).
 
-
-% Macro printing the given message to stderr.
+%% Macro printing the given message to stderr.
 -define (stderr (Msg, Args),
     io:put_chars(standard_error, io_lib:format(Msg, Args))).
 
 -define (stderr (Msg), ?stderr(Msg, [])).
 
-
-% The runner will be called without arguments in case no tests were found .
-% Print a descriptive error message, then exit.
+%% The runner will be called without arguments in case no tests were found .
+%% Print a descriptive error message, then exit.
 run_all() ->
     ?stderr("etest: No tests found~n"),
     erlang:halt().
 
 
 run_all(Modules) ->
-    % Init statistics.
+    %% Init statistics.
     [put(K, 0) || K <- [errors, success, tests]],
 
     lists:foreach(fun run/1, Modules),
@@ -30,6 +28,9 @@ run_all(Modules) ->
 
     erlang:halt(get(errors)).
 
+%%% ===================================================================
+%%%  Private functions
+%%% ===================================================================
 
 run(Module) ->
     Funs = testfuns(Module),
@@ -53,6 +54,32 @@ run(Module) ->
     lists:foreach(TryTest, ToRun).
 
 
+is_a_test() ->
+    fun({FunName, _}) ->
+            nomatch =/= re:run(atom_to_list(FunName), "^test_")
+    end.
+
+
+get_values(Values, PropList) ->
+    get_values(Values, PropList, []).
+get_values([], _, Accum) ->
+    lists:flatten(Accum);
+get_values([V|Values], PropList, Accum) ->
+    ValTuple = case proplists:lookup(V, PropList) of
+                   none -> [];
+                   Other when is_tuple(Other) -> Other
+               end,
+    get_values(Values, PropList, [ValTuple | Accum]).
+
+
+is_member(_Val, []) ->
+    false;
+is_member(Val, [{_, L} | Rest]) when is_list(L) ->
+    case lists:member(Val, L) of
+        true  -> true;
+        false -> is_member(Val, Rest)
+    end.
+
 
 testfuns(Module) ->
     Exports = try
@@ -63,18 +90,23 @@ testfuns(Module) ->
             erlang:halt(1)
     end,
 
-    IsFocus = fun({FunName, _}) ->
-        nomatch =/= re:run(atom_to_list(FunName), "^focus_test_")
-    end,
-
-    TestFuns = case lists:filter(IsFocus, Exports) of
-        [] ->
-            IsTest = fun({FunName, _}) ->
-                nomatch =/= re:run(atom_to_list(FunName), "^test_")
-            end,
-            lists:filter(IsTest, Exports);
-        FocusTests -> FocusTests
-    end,
+    AllTestFuns = lists:filter(is_a_test(), Exports),
+    TestFuns = case init:get_argument(group) of
+                   error -> AllTestFuns;
+                   {ok, [[]]} -> AllTestFuns;
+                   {ok, [Groups]} ->
+                       %%% Query the module for grouped functions, filter
+                       %%% exported functions to be only those defined in the
+                       %%% Group provided by the user.
+                       case (maybe_fun(Module, groups))() of
+                           ok -> [];
+                           Funs ->
+                               GroupFuns = get_values(Groups, Funs),
+                               lists:filter(fun({FunName, _}) ->
+                                                    is_member(FunName, GroupFuns)
+                                            end, AllTestFuns)
+                       end
+               end,
 
     MakeApplicative = fun({FunName, _}) ->
         fun() ->
@@ -97,17 +129,11 @@ apply_callbacks(Module, Funs) ->
         || Fun <- Funs
     ].
 
-
 maybe_fun(Module, FunName) ->
-    case has_fun(Module, FunName) of
+    case erlang:function_exported(Module, FunName, 0) of
         true  -> fun() -> Module:FunName() end;
         false -> fun() -> ok end
     end.
-
-
-has_fun(Module, FunName) ->
-    Exports = Module:module_info(exports),
-    proplists:is_defined(FunName, Exports).
 
 
 clean_trace(Trace0) ->

--- a/test/my_second_test.erl
+++ b/test/my_second_test.erl
@@ -2,5 +2,16 @@
 -compile(export_all).
 -include ("etest.hrl").
 
+groups() ->
+    [{"slow", [test_bar, test_baz]}].
+
 test_foo() ->
     ?assert_equal(true, false).
+
+test_bar() ->
+    timer:sleep(1000),
+    ?assert_equal(true, true).
+
+test_baz() ->
+    timer:sleep(1000),
+    ?assert_not_equal(true, false).

--- a/test/my_third_test.erl
+++ b/test/my_third_test.erl
@@ -3,4 +3,5 @@
 -compile(export_all).
 
 test_foo() ->
-    1 = 2.
+    A = 1,
+    A = 2.


### PR DESCRIPTION
This is a somewhat invasive patch set which allows the running of tests by group, which I found myself in strong need of. I found myself picking common set of tests out and appending 'focus_' to their names regularly, which was not entirely workable--it took time to do this and was error prone. What I needed was the ability to run either all tests or a single group.
    
This patch set adds this capability to etest, as well modifications I found helpful when developing these changes. 

Most notably, and perhaps contentiously, I've abandoned the focus test concept entirely; I found keeping it made for awkward code and that the concept felt like a redundant complexity when using etest + groups.