### PR TITLE
fix rebar3 dependency path

### DIFF
--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -15,4 +15,4 @@ do
 done
 
 # Invoke runner, assuming all files have been compiled to `ebin/`.
-erl $ETEST_ARGS -noshell -noinput -pa deps/*/ebin apps/*/ebin deps/elixir/lib/*/ebin ebin -s etest_runner run_all $modules
+erl $ETEST_ARGS -noshell -noinput -pa deps/*/ebin apps/*/ebin deps/elixir/lib/*/ebin _build/default/lib/**/ebin ebin -s etest_runner run_all $modules


### PR DESCRIPTION
Hi,

I just started learning Erlang and found this tool. I noticed that the command for running etest didn't work for me, because the wrapper script bin/etest-runner doesn't know of the different project structure of rebar3. Hence, I added a new path, which works fine for me now. Is there another way, that I'm just missing?
