### PR TITLE
New Feature: Test Coverage Reports & General Modernisation for rebar3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 etest is a lightweight, convention-over-configuration test framework for
 Erlang.
 
-* etest expects an Erlang application / rebar-compatible directory structure
-  with the following top level directories: _src_, _deps_, _ebin_ and _test_.
+* etest expects an Erlang application / rebar3-compatible directory structure
+  with the following top level directories: `src`,  and `test`.
 
 * Test module file names end with `_test.erl` ending and test case
   function names should start with `test_`.
@@ -109,7 +109,6 @@ focus_test_foo() ->
     ?assert(true).
 ```
 
-
 ## Demo
 
 There is a quick screencast on vimeo that shows how to use etest in your
@@ -145,16 +144,86 @@ After updating your rebar.config, run ```rebar get-deps``` to install etest.
 ## Running the Tests
 
 Before running the tests, they need to be compiled by running
-```rebar compile```. You can write a simple shell script that compiles
+```rebar3 compile```. You can write a simple shell script that compiles
 everything before running the tests to make your life easier.
 
-In your project directory, run ```deps/etest/bin/etest-runner``` to execute all
-tests in the `test` directory.
+Etest comes with a test runner, which by default, is buried in the _build directory
+```_build/default/lib/etest/bin/etest-runner```
 
-Run ```deps/etest/bin/etest-runner test/integration/user_login_test.erl``` to
-execute a single test file.
+For convenience you can either symlink it to a top level direcory or create a ```make``` task
+
+
+### Run All The Tests
+
+```
+# If you have symlinked it to your app root directory
+./etest-runner
+
+# If you want to run it from the _build dir
+_build/default/lib/etest/bin/etest_runner
+```
+
+### Run a Single Test
+```
+etest-runner test/integration/user_login_test.erl
+```
+
+### Test Coverage Report
+
+If you want to know how much of your codebase is covered by etest tests, you can set two additional enironment variables (ETEST_BUILD_DIR and WITH_COVERAGE. This will create a `coverage` directory in you app root directory in which you will find the html reports.
+
+Run the tests like this where `ETEST_BUILD_DIR` is the build dir of your app so etest knows which modules to cover and with `WITH_COVERAGE=true` to tell it to generate the report.
+
+```
+rebar3 compile && \
+	ETEST_ARGS="-config config/test.config" \
+	WITH_COVERAGE=yes \
+	ETEST_BUILD_DIR="_build/default/lib/[YOUR_APP_NAME]" \
+	_build/default/lib/etest/bin/etest-runner
+```
+
+This will run the tests, save the report html files in ./coverage and create some ascii output like this
+
+```
++==========================================================+
+| Coverage Report                                          |
++================================================+=========+
+| Module                                         | Percent |
++------------------------------------------------+---------+
+| myapp_app                                      |  100.00 |
+| myapp_config                                   |   91.67 |
+| myapp_default_handler                          |   84.21 |
+| myapp_session                                  |   85.19 |
+| myapp_session_handler                          |   90.32 |
+| myapp_session_middleware                       |   54.55 |
+| myapp_session_store                            |   69.05 |
+| myapp_sql                                      |   75.00 |
+| myapp_sql_worker                               |   70.59 |
+| myapp_sup                                      |  100.00 |
+| myapp_user                                     |   80.00 |
+| myapp_users_handler                            |  100.00 |
+| myapp_utils                                    |   87.50 |
+| myapp_view                                     |   96.15 |
++================================================+=========+
+
+=========================================
+  Failed: 0.  Success: 25.  Total: 25.
+```
+
+### Passing Arguments to erl
 
 To pass additional arguments to the `erl` command you can use the
-environment variable `ERL_AFLAGS`. For example:
+environment variable `ETEST_ARGS`. For example:
 
-    ERL_AFLAGS="-config priv/config/test.config" deps/etest/bin/etest-runner
+```
+ETEST_ARGS="-config config/test.config" deps/etest/bin/etest-runner
+```
+
+### Makefile Example
+
+For absolute convenience here is an example Makefile task which will run all tests with coverage report for the ```myapp``` app
+
+```
+test:
+	rebar3 compile && ETEST_ARGS="-config config/test.config" WITH_COVERAGE=yes ETEST_BUILD_DIR="_build/default/lib/myapp" _build/default/lib/etest/bin/etest-runner
+```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 etest is a lightweight, convention-over-configuration test framework for
 Erlang.
 
+It comes with a companion library for testing http / web apps and APIs which is
+called [etest_http](https://github.com/wooga/etest_http)
+
 * etest expects an Erlang application / rebar3-compatible directory structure
   with the following top level directories: `src`,  and `test`.
 

--- a/README.md
+++ b/README.md
@@ -134,15 +134,11 @@ the tests manually.
 
 % Dependencies
 {deps, [
-    {etest, ".*", {git, "git://github.com/wooga/etest.git"}}
-]}.
-
-% Which files to cleanup when rebar clean is executed.
-{clean_files, ["ebin/*.beam"]}.
+    {etest, "1.2.0"}
+]}
 ```
 
-After updating your rebar.config, run ```rebar get-deps``` to install etest.
-
+After updating your rebar.config, run ```rebar3 get-deps``` to install etest.
 
 ## Running the Tests
 

--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -21,4 +21,4 @@ do
 done
 
 # Invoke runner, assuming all files have been compiled to `ebin/`.
-erl $ETEST_ARGS -noshell -noinput -pa _build/default/lib/*/ebin -s etest_runner run_all $modules
+erl $ETEST_ARGS -noshell -noinput -pa _build/default/lib/*/ebin -s etest_runner init $modules

--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -6,8 +6,11 @@ if [ $# -eq 0 ]
     else test_files=$@;
 fi
 
-# Create Coverage Folder
-mkdir -p coverage
+if [[ ! -z $WITH_COVERAGE ]]
+then
+    # Create Coverage Folder
+    mkdir -p coverage
+fi
 
 # Map test files to modules names.
 modules=""

--- a/bin/etest-runner
+++ b/bin/etest-runner
@@ -6,6 +6,9 @@ if [ $# -eq 0 ]
     else test_files=$@;
 fi
 
+# Create Coverage Folder
+mkdir -p coverage
+
 # Map test files to modules names.
 modules=""
 for file in $test_files

--- a/include/etest.hrl
+++ b/include/etest.hrl
@@ -120,7 +120,7 @@
                             })
                   catch
                       Class:Term -> true;
-                      __C:__T ->
+                      __C:__T:__S ->
                           erlang:error(
                             {assert_exception,
                              [{module,     ?MODULE},
@@ -128,7 +128,7 @@
                               {expression, (??Expr)},
                               {pattern,    "{" ++ (??Class) ++ ", " ++ (??Term) ++ ", [...]}"},
                               {unexpected_exception,
-                               {__C, __T, erlang:get_stacktrace()}}]
+                               {__C, __T, __S}}]
                             })
                   end
           end)())).
@@ -144,7 +144,7 @@
                   try (Expr) of
                       _ -> true
                   catch
-                      __C:__T ->
+                      __C:__T:__S ->
                           case {__C, __T} of
                               {Class, Term} ->
                                   erlang:error(
@@ -155,7 +155,7 @@
                                       {pattern,
                                        "{" ++ (??Class) ++ ", " ++ (??Term) ++ ", [...]}"},
                                       {unexpected_exception,
-                                       {__C, __T, erlang:get_stacktrace()}}]
+                                       {__C, __T, __S}}]
                                     });
                               _ -> true
                           end

--- a/src/etest.app.src
+++ b/src/etest.app.src
@@ -1,8 +1,10 @@
 {application, etest, [
-    {description, "A small Erlang testing framework"},
-    {vsn, git},
+    {description, "A lightweight and fast testing framework for Erlang"},
+    {vsn, "1.2.0"},
+    {maintainers, ["John-Paul Bader"]},
+    {links, [{"Github", "https://github.com/wooga/etest"}]},
+    {licenses, ["BSD-2-Clause"]},
     {registered, []},
     {modules, []},
-    {applications, []},
-    {env, []}
+    {applications, []}
 ]}.

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -12,7 +12,7 @@
 
 init(Modules) ->
      % Check if coverage report should be generated
-    WithCoverage = os:getenv("WITH_COVER"),
+    WithCoverage = os:getenv("WITH_COVERAGE"),
 
 
     case WithCoverage of

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -46,8 +46,7 @@ run_all(Modules) ->
     {result, CoverData, _} = cover:analyse(cover:modules()),
 
     % Accumulate Covered / Not Covered Lines per module
-    CoverDataFun = fun
-        ({{M, _F, _A}, {Covered, NotCovered}}, Acc) ->
+    CoverDataFun = fun({{M, _F, _A}, {Covered, NotCovered}}, Acc) ->
         {OldCovered, OldNotCovered} = maps:get(M, Acc, {0, 0}),
         Acc#{M => { OldCovered + Covered, OldNotCovered + NotCovered }}
     end,
@@ -62,7 +61,8 @@ run_all(Modules) ->
 
     CoverResultPercentage = maps:map(PercentFun, CoverResult),
 
-    io:format("COVER ~p~n", [CoverResultPercentage]),
+    % TODO This needs better formatting
+    io:format("Coverage Report ~p~n", [CoverResultPercentage]),
 
     Errors = get(errors),
     SummaryColor = case Errors == 0 of

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -99,9 +99,9 @@ run_test(Test) ->
     try
         Test()
     catch
-        _:Error ->
+        _:Error:Stacktrace ->
             inc(errors),
-            format_error("Test ", Error, clean_trace(erlang:get_stacktrace()))
+            format_error("Test ", Error, clean_trace(Stacktrace))
     end,
 
     After  = erlang:monotonic_time(),
@@ -130,8 +130,8 @@ require_hook(Fun, Name) ->
         After = erlang:monotonic_time(),
         erlang:convert_time_unit(After - Before, native, milli_seconds)
     catch
-        _:Error ->
-            format_error(Name, Error, clean_trace(erlang:get_stacktrace())),
+        _:Error:Stacktrace ->
+            format_error(Name, Error, clean_trace(Stacktrace)),
             io:format("~n"),
             erlang:halt(1)
     end.

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -14,7 +14,6 @@ init(Modules) ->
      % Check if coverage report should be generated
     WithCoverage = os:getenv("WITH_COVERAGE"),
 
-
     case WithCoverage of
         false ->
             % Run the tests

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -1,5 +1,6 @@
--module (etest_runner).
--compile (export_all).
+-module(etest_runner).
+
+-export([run_all/0, run_all/1]).
 
 
 % Macro printing the given message to stderr.

--- a/src/etest_runner.erl
+++ b/src/etest_runner.erl
@@ -67,8 +67,7 @@ run_all(Modules) ->
 
     CoverResultPercentage = maps:map(PercentFun, CoverResult),
 
-    % TODO This needs better formatting
-    io:format("Coverage Report ~p~n", [CoverResultPercentage]),
+    print_coverage_report(CoverResultPercentage),
 
     Errors = get(errors),
     SummaryColor = case Errors == 0 of
@@ -212,3 +211,22 @@ clean_trace(Trace0) ->
 
 inc(Name) ->
     put(Name, get(Name) + 1).
+
+
+print_coverage_report(CoverageData) ->
+    Header = ["+==========================================================+",
+              "| Coverage Report                                          |",
+              "+================================================+=========+",
+              "| Module                                         | Percent |",
+              "+------------------------------------------------+---------+"],
+    io:format("~n~s~n~s~n~s~n~s~n~s~n", Header),
+
+    PrintFun = fun({Module, Percent}) ->
+        StringModule = erlang:atom_to_list(Module),
+        io:format("| ~s | ~s |~n", [string:left(StringModule, 46), string:right(Percent, 7)])
+    end,
+
+    lists:foreach(PrintFun, maps:to_list(CoverageData)),
+
+    Footer = "+==========================================================+",
+    io:format("~s~n~n", [Footer]).


### PR DESCRIPTION
When adding the WITH_COVERAGE=yes and ETEST_BUILD_DIR flags when executing the etest-runner, etest will now user erlangs `cover` tool for generating test coverage reports. 

See the updated readme for all the details.

Also I've removed some deprecation warnings and updated the readme to reflect rebar3 changes.

Lastly etest is now prepared to be released as hex.pm package. 

Feedback welcome